### PR TITLE
fix: separate 'authCheck' from 'auth' file

### DIFF
--- a/client/src/components/AuthComponents/withAuthGSSP.js
+++ b/client/src/components/AuthComponents/withAuthGSSP.js
@@ -1,4 +1,4 @@
-import authCheck from '@/lib/auth';
+import authCheck from '@/lib/token';
 
 const withAuthServerSideProps = (getServerSidePropsFunc) => {
   return async (ctx) => {

--- a/client/src/lib/auth.js
+++ b/client/src/lib/auth.js
@@ -1,24 +1,7 @@
 import Router from 'next/router';
 import ky from 'ky-universal';
-import cookie from 'cookie';
-import { verify } from 'jsonwebtoken';
 import HOST from '@/lib/host';
 const api = `${HOST}/api/auth`;
-const secret = process.env.SECRET;
-
-const authCheck = async (ctx) => {
-  const noAuth = { username: null, role: null };
-
-  const reqCookie = ctx.req.headers.cookie;
-  if (!reqCookie) return noAuth; // No token
-
-  const cookies = cookie.parse(reqCookie);
-  const payload = verify(cookies.auth, secret);
-  if (!payload) return noAuth; // Invalid token
-
-  const { username, role } = payload;
-  return (username && role) ? { username, role } : noAuth;
-};
 
 export const signup = async (data) => {
   try {
@@ -63,5 +46,3 @@ export const logout = async () => {
   await ky.post(`${api}/logout`, { json: { 'message': 'Log out' }});
   Router.reload();
 };
-
-export default authCheck;

--- a/client/src/lib/token.js
+++ b/client/src/lib/token.js
@@ -1,0 +1,19 @@
+import cookie from 'cookie';
+import { verify } from 'jsonwebtoken';
+const secret = process.env.SECRET;
+
+const authCheck = async (ctx) => {
+  const noAuth = { username: null, role: null };
+
+  const reqCookie = ctx.req.headers.cookie;
+  if (!reqCookie) return noAuth; // No token
+
+  const cookies = cookie.parse(reqCookie);
+  const payload = verify(cookies.auth, secret);
+  if (!payload) return noAuth; // Invalid token
+
+  const { username, role } = payload;
+  return (username && role) ? { username, role } : noAuth;
+};
+
+export default authCheck;


### PR DESCRIPTION
It bloats the bundle size because of the 'verify' function from
'jsonwebtoken' being imported into the client, when normally it only
runs in the Node server (via getServerSideProps)